### PR TITLE
Clean docker config before usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ Example usage:
 ## Visualize
 
 ```shell
-opctl ui github.com/opspec-pkgs/docker.build.localimage#1.1.0
+opctl ui github.com/opspec-pkgs/docker.build.localimage#1.1.1
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/docker.build.localimage#1.1.0
+opctl run github.com/opspec-pkgs/docker.build.localimage#1.1.1
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/docker.build.localimage#1.1.0
+  ref: github.com/opspec-pkgs/docker.build.localimage#1.1.1
   inputs:
     dockerSocket:  # 👈 required; provide a value
     imageName:  # 👈 required; provide a value

--- a/op.yml
+++ b/op.yml
@@ -1,5 +1,6 @@
 ---
 name: github.com/opspec-pkgs/docker.build.localimage
+version: 1.1.1
 description: |
   Build a docker image in your host machines docker image store. Once a successful run of this op completes, you should see your new container created on the host machine when you run `docker images`.
 
@@ -65,6 +66,12 @@ inputs:
         The name (tag) of the built image. e.g. "container_name:latest".
 run:
   serial:
+  - op:
+      ref: github.com/opspec-pkgs/docker.config.clean#1.0.0
+      inputs:
+        dockerConfig:
+      outputs:
+        dockerConfigCleaned: $(dockerConfig)
   - container:
       image: { ref: 'docker:18.09.0-dind' }
       files:
@@ -81,5 +88,3 @@ run:
           cat /Dockerfile | docker image build \
             --progress plain \
             -t "$imageName" -
-
-version: 1.1.0


### PR DESCRIPTION
This pipes the docker config through a new op - https://github.com/opspec-pkgs/docker.config.clean, which removes the credential helper. I don't think I saw this before, because I'd only tested things that had images cached locally? I hit this error eventually though, which this resolves:

```
failed to solve with frontend dockerfile.v0: failed to create LLB definition: rpc error: code = Unknown desc = error getting credentials - err: exec: "docker-credential-desktop": executable file not found in $PATH, out: ``
```