### PR TITLE
Upgrades dependent op to a version which is more stable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,9 @@ All notable changes will be documented in this file in accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
 ## \[Unreleased]
+
+## [1.1.3] - 2024-05-15
+
+### Changed
+
+- Updated dependant docker.config.clean op which broke

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example usage:
 
 ```yml
   op:
-    ref: github.com/opspec-pkgs/docker.build.localimage#1.1.2
+    ref: github.com/opspec-pkgs/docker.build.localimage#1.1.3
     inputs:
       imageName: my-image
       dockerfile: $(/Dockerfile)
@@ -21,7 +21,7 @@ Example usage:
 
 ```yml
   op:
-    ref: github.com/opspec-pkgs/docker.build.localimage#1.1.2
+    ref: github.com/opspec-pkgs/docker.build.localimage#1.1.3
     inputs:
       imageName: my-image
       dockerfile: $(/Dockerfile)
@@ -35,20 +35,20 @@ Example usage:
 ## Visualize
 
 ```shell
-opctl ui github.com/opspec-pkgs/docker.build.localimage#1.1.2
+opctl ui github.com/opspec-pkgs/docker.build.localimage#1.1.3
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/docker.build.localimage#1.1.2
+opctl run github.com/opspec-pkgs/docker.build.localimage#1.1.3
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/docker.build.localimage#1.1.2
+  ref: github.com/opspec-pkgs/docker.build.localimage#1.1.3
   inputs:
     dockerSocket:  # 👈 required; provide a value
     imageName:  # 👈 required; provide a value

--- a/op.yml
+++ b/op.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/opspec-pkgs/docker.build.localimage
-version: 1.1.2
+version: 1.1.3
 description: |
   Build a docker image in your host machines docker image store. Once a successful run of this op completes, you should see your new container created on the host machine when you run `docker images`.
 
@@ -8,7 +8,7 @@ description: |
 
   ```yml
     op:
-      ref: github.com/opspec-pkgs/docker.build.localimage#1.1.2
+      ref: github.com/opspec-pkgs/docker.build.localimage#1.1.3
       inputs:
         imageName: my-image
         dockerfile: $(/Dockerfile)
@@ -21,7 +21,7 @@ description: |
 
   ```yml
     op:
-      ref: github.com/opspec-pkgs/docker.build.localimage#1.1.2
+      ref: github.com/opspec-pkgs/docker.build.localimage#1.1.3
       inputs:
         imageName: my-image
         dockerfile: $(/Dockerfile)
@@ -67,7 +67,7 @@ inputs:
 run:
   serial:
   - op:
-      ref: github.com/opspec-pkgs/docker.config.clean#1.0.1
+      ref: github.com/opspec-pkgs/docker.config.clean#1.1.0
       inputs:
         dockerConfig:
       outputs:


### PR DESCRIPTION
Needs https://github.com/opspec-pkgs/docker.config.clean/pull/4

Updates to use a version of the dependency which isn't broken.